### PR TITLE
Add half pipe skate demo with controls

### DIFF
--- a/docs/HalfPipeGameScope.md
+++ b/docs/HalfPipeGameScope.md
@@ -1,0 +1,28 @@
+# Half Pipe Skate Game Scope
+
+This document outlines the scope, deployment and testing steps for the sample half pipe game built on the Just Forge 2D framework.
+
+## Scope
+- One isometric half pipe background.
+- Single skater represented by a simple circle.
+- Keyboard and gamepad input support.
+- Menu scene with start prompt.
+- In-game control overlay with at least ten trick combinations using `Ctrl` or `Alt` plus directional input.
+
+## Deployment
+1. Build the project:
+   ```bash
+   ./gradlew build
+   ```
+2. Run the game locally:
+   ```bash
+   java -jar build/libs/Just_Forge_2D.jar
+   ```
+3. For web hosting (e.g. Vercel), ensure `vercel.json` points to `index.html` and deploy the static files.
+
+## Testing
+- Verify the project compiles with `./gradlew build`.
+- Launch the game and confirm:
+  - Menu scene appears and `Enter` or gamepad `Start` loads the game.
+  - Skater moves with arrow keys or left stick.
+  - Performing the listed key combinations displays the corresponding trick names.

--- a/src/main/java/Just_Forge_2D/GameDemo/HalfPipeSceneScript.java
+++ b/src/main/java/Just_Forge_2D/GameDemo/HalfPipeSceneScript.java
@@ -1,0 +1,106 @@
+package Just_Forge_2D.GameDemo;
+
+import Just_Forge_2D.SceneSystem.Scene;
+import Just_Forge_2D.SceneSystem.SceneScript;
+import Just_Forge_2D.InputSystem.Keyboard;
+import Just_Forge_2D.InputSystem.Keys;
+import Just_Forge_2D.InputSystem.Gamepad;
+import Just_Forge_2D.RenderingSystem.DebugPencil;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+import imgui.ImGui;
+import imgui.flag.ImGuiWindowFlags;
+
+import java.util.Arrays;
+
+import static org.lwjgl.glfw.GLFW.*;
+
+/**
+ * Simple half pipe skating demo.
+ */
+public class HalfPipeSceneScript extends SceneScript {
+    private Vector2f skaterPos = new Vector2f(300, 150);
+    private String trickMessage = "";
+    private float trickTimer = 0f;
+
+    @Override
+    public void init(Scene scene) {
+    }
+
+    @Override
+    public void loadResources(Scene scene) {
+    }
+
+    @Override
+    public void update(float dt) {
+        float move = 200 * dt;
+        boolean left = Keyboard.isKeyPressed(Keys.ARROW_LEFT) || Gamepad.getAxis(GLFW_GAMEPAD_AXIS_LEFT_X) < -0.5f;
+        boolean right = Keyboard.isKeyPressed(Keys.ARROW_RIGHT) || Gamepad.getAxis(GLFW_GAMEPAD_AXIS_LEFT_X) > 0.5f;
+        boolean up = Keyboard.isKeyPressed(Keys.ARROW_UP) || Gamepad.getAxis(GLFW_GAMEPAD_AXIS_LEFT_Y) < -0.5f;
+        boolean down = Keyboard.isKeyPressed(Keys.ARROW_DOWN) || Gamepad.getAxis(GLFW_GAMEPAD_AXIS_LEFT_Y) > 0.5f;
+        if (left) skaterPos.x -= move;
+        if (right) skaterPos.x += move;
+        if (up) skaterPos.y += move;
+        if (down) skaterPos.y -= move;
+
+        boolean ctrl = Keyboard.isKeyPressed(Keys.LEFT_CONTROL) || Keyboard.isKeyPressed(Keys.RIGHT_CONTROL) || Gamepad.isAPressed();
+        boolean alt = Keyboard.isKeyPressed(Keys.LEFT_ALT) || Keyboard.isKeyPressed(Keys.RIGHT_ALT) || Gamepad.isBPressed();
+
+        checkTricks(ctrl, alt, up, down, left, right);
+
+        if (trickTimer > 0) {
+            trickTimer -= dt;
+        }
+    }
+
+    private void checkTricks(boolean ctrl, boolean alt, boolean up, boolean down, boolean left, boolean right) {
+        if (ctrl && up && left) setTrick("720 Spin");
+        else if (ctrl && up && right) setTrick("McTwist");
+        else if (ctrl && up) setTrick("Kickflip");
+        else if (ctrl && down) setTrick("Heelflip");
+        else if (ctrl && left) setTrick("Caballerial");
+        else if (ctrl && right) setTrick("Ollie");
+        else if (alt && up && right) setTrick("FS Air");
+        else if (alt && up) setTrick("Nose Grab");
+        else if (alt && down) setTrick("Tail Grab");
+        else if (alt && left) setTrick("Indy");
+        else if (alt && right) setTrick("Mute");
+    }
+
+    private void setTrick(String name) {
+        trickMessage = name;
+        trickTimer = 2f;
+    }
+
+    @Override
+    public void render(float dt) {
+        Vector2f[] pipe = new Vector2f[] {
+                new Vector2f(100, 100),
+                new Vector2f(500, 100),
+                new Vector2f(550, 250),
+                new Vector2f(50, 250)
+        };
+        DebugPencil.addPolygonFromVertices(Arrays.asList(pipe), new Vector3f(0.8f, 0.8f, 0.8f), 1);
+        DebugPencil.addCircle(skaterPos, 10f, new Vector3f(1f, 0f, 0f), 1);
+
+        if (trickTimer > 0) {
+            ImGui.begin("Trick", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground);
+            ImGui.text(trickMessage);
+            ImGui.end();
+        }
+
+        ImGui.begin("Controls", ImGuiWindowFlags.AlwaysAutoResize);
+        ImGui.text("Ctrl + Up : Kickflip");
+        ImGui.text("Ctrl + Down : Heelflip");
+        ImGui.text("Ctrl + Left : Caballerial");
+        ImGui.text("Ctrl + Right : Ollie");
+        ImGui.text("Ctrl + Up + Left : 720 Spin");
+        ImGui.text("Ctrl + Up + Right : McTwist");
+        ImGui.text("Alt + Up : Nose Grab");
+        ImGui.text("Alt + Down : Tail Grab");
+        ImGui.text("Alt + Left : Indy");
+        ImGui.text("Alt + Right : Mute");
+        ImGui.text("Alt + Up + Right : FS Air");
+        ImGui.end();
+    }
+}

--- a/src/main/java/Just_Forge_2D/GameDemo/MenuSceneScript.java
+++ b/src/main/java/Just_Forge_2D/GameDemo/MenuSceneScript.java
@@ -1,0 +1,38 @@
+package Just_Forge_2D.GameDemo;
+
+import Just_Forge_2D.SceneSystem.Scene;
+import Just_Forge_2D.SceneSystem.SceneScript;
+import Just_Forge_2D.WindowSystem.GameWindow;
+import Just_Forge_2D.InputSystem.Keyboard;
+import Just_Forge_2D.InputSystem.Keys;
+import Just_Forge_2D.InputSystem.Gamepad;
+import imgui.ImGui;
+import imgui.flag.ImGuiWindowFlags;
+
+/**
+ * Simple menu scene that starts the half pipe game.
+ */
+public class MenuSceneScript extends SceneScript {
+    @Override
+    public void init(Scene scene) {
+    }
+
+    @Override
+    public void loadResources(Scene scene) {
+    }
+
+    @Override
+    public void update(float dt) {
+        if (Keyboard.isKeyBeginPress(Keys.ENTER) || Gamepad.isStartPressed()) {
+            GameWindow.changeScene(new HalfPipeSceneScript());
+        }
+    }
+
+    @Override
+    public void render(float dt) {
+        ImGui.begin("Half Pipe Menu", ImGuiWindowFlags.AlwaysAutoResize);
+        ImGui.text("Half Pipe Skate Game");
+        ImGui.text("Press Enter or Start to play");
+        ImGui.end();
+    }
+}

--- a/src/main/java/Just_Forge_2D/InputSystem/Gamepad.java
+++ b/src/main/java/Just_Forge_2D/InputSystem/Gamepad.java
@@ -1,0 +1,51 @@
+package Just_Forge_2D.InputSystem;
+
+import org.lwjgl.glfw.GLFWGamepadState;
+
+import static org.lwjgl.glfw.GLFW.*;
+
+/**
+ * Basic gamepad input helper supporting a single controller.
+ */
+public class Gamepad {
+    private static Gamepad instance;
+    private final GLFWGamepadState state = GLFWGamepadState.create();
+
+    private Gamepad() {
+    }
+
+    private static Gamepad get() {
+        if (instance == null) {
+            instance = new Gamepad();
+        }
+        return instance;
+    }
+
+    private static boolean poll() {
+        if (!glfwJoystickPresent(GLFW_JOYSTICK_1)) return false;
+        if (!glfwJoystickIsGamepad(GLFW_JOYSTICK_1)) return false;
+        return glfwGetGamepadState(GLFW_JOYSTICK_1, get().state);
+    }
+
+    public static boolean isButtonPressed(int button) {
+        if (!poll()) return false;
+        return get().state.buttons(button) == 1;
+    }
+
+    public static float getAxis(int axis) {
+        if (!poll()) return 0.0f;
+        return get().state.axes(axis);
+    }
+
+    public static boolean isStartPressed() {
+        return isButtonPressed(GLFW_GAMEPAD_BUTTON_START);
+    }
+
+    public static boolean isAPressed() {
+        return isButtonPressed(GLFW_GAMEPAD_BUTTON_A);
+    }
+
+    public static boolean isBPressed() {
+        return isButtonPressed(GLFW_GAMEPAD_BUTTON_B);
+    }
+}

--- a/src/main/java/Just_Forge_2D/Main.java
+++ b/src/main/java/Just_Forge_2D/Main.java
@@ -1,12 +1,14 @@
 package Just_Forge_2D;
 
 import Just_Forge_2D.EditorSystem.Forge;
+import Just_Forge_2D.WindowSystem.GameWindow;
+import Just_Forge_2D.GameDemo.MenuSceneScript;
 
-
-public class Main
-{
-    public static void main(String[] args)
-    {
-        Forge.run();
+public class Main {
+    public static void main(String[] args) {
+        Forge.start();
+        GameWindow.changeScene(new MenuSceneScript());
+        GameWindow.get().run();
+        Forge.end();
     }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add gamepad input helper
- add menu and half-pipe game scenes with 10+ trick combos and on-screen controls
- document scope and deployment steps; add vercel config

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688d7c2735b08329b56bb25f017e42fc